### PR TITLE
Droog/feature/spi burst readout

### DIFF
--- a/Core/Inc/drivers/spi/spi_bitbang.h
+++ b/Core/Inc/drivers/spi/spi_bitbang.h
@@ -58,6 +58,9 @@ uint8_t read_spi_reg(uint8_t addr, uint8_t sensor);
 bool write_spi_reg(uint8_t addr, uint8_t packet, uint8_t sensor);
 void spi_read_multiple_bytes(uint8_t addr, uint32_t length, uint8_t sensor);
 
+uint8_t spi_read_burst(uint8_t sensor);
+void spi_init_burst(uint8_t sensor);
+void spi_deinit_burst(uint8_t sensor);
 GPIO_PinState bit_read(uint8_t byte, int j);
 // void delay_us (uint32_t nus);
 #endif /* INC_SPI_BITBANG_H_ */

--- a/Core/Inc/iris_system.h
+++ b/Core/Inc/iris_system.h
@@ -69,8 +69,8 @@ void Error_Handler(void);
 /* Iris Model Defines --------------------------------------------------------*/
 //#define IRIS_EM
 //#define IRIS_FM
-
 #define IRIS_PROTO
+
 
 #ifdef IRIS_FM
 #define CURRENTSENSE_5V 0x40

--- a/Core/Src/command_handler.c
+++ b/Core/Src/command_handler.c
@@ -17,6 +17,11 @@ extern int format;
 extern int width;
 extern const struct sensor_reg OV5642_JPEG_Capture_QSXGA[];
 extern const struct sensor_reg OV5642_QVGA_Preview[];
+
+uint8_t VIS_DETECTED = 0;
+uint8_t NIR_DETECTED = 0;
+
+
 /*
  * todo:
  * 		- 	TEST THESE FUNCTIONS EH
@@ -235,7 +240,8 @@ void initalize_sensors(void) {
     uint8_t res = onboot_sensors(VIS_SENSOR);
 	if (res == 1){
 		program_sensor(format, VIS_SENSOR);
-	DBG_PUT("VIS Camera Mode: JPEG\r\nI2C address: 0x3C\r\n\n");
+		DBG_PUT("VIS Camera Mode: JPEG\r\nI2C address: 0x3C\r\n\n");
+		VIS_DETECTED = 1;
 	}
 	if (res == -1){
 		// need some error handling eh
@@ -247,7 +253,8 @@ void initalize_sensors(void) {
     res = onboot_sensors(NIR_SENSOR);
 	if (res == 1){
 		program_sensor(format, NIR_SENSOR);
-	DBG_PUT("NIR Camera Mode: JPEG\r\nI2C address: 0x3D\r\n\n");
+		DBG_PUT("NIR Camera Mode: JPEG\r\nI2C address: 0x3D\r\n\n");
+		NIR_DETECTED = 1;
 	}
 	if (res == -1){
 		// need some error handling eh

--- a/Core/Src/drivers/arducam/arducam.c
+++ b/Core/Src/drivers/arducam/arducam.c
@@ -170,12 +170,7 @@ int arducam_set_resolution(int format, int width, uint8_t sensor) {
         if (format == RAW)
             arducam_raw_init(2592, 1944, sensor);
         else {
-#if 0
             wrSensorRegs16_8(ov5642_2592x1944, sensor);
-#else
-            DBG_PUT("2592x1944 not supported");
-            rc = 0;
-#endif
         }
         break;
     default:

--- a/Core/Src/drivers/arducam/arducam.c
+++ b/Core/Src/drivers/arducam/arducam.c
@@ -5,6 +5,8 @@
 #include "flash_cmds.h"
 #include "I2C.h"
 #include "debug.h"
+#include "spi_bitbang.h"
+extern UART_HandleTypeDef huart1;
 
 // probs needs to be re-evaluated
 uint8_t image_number = 0;
@@ -441,65 +443,70 @@ static inline uint32_t min(uint32_t a, uint32_t b) { return (a <= b) ? a : b; }
 //
 //#define BUF_LEN 64
 //
-//static void dump_uart_jpg(uint32_t length, uint8_t sensor) {
-//    uint8_t prev = 0, curr = 0;
-//    bool found_header = false;
-//    uint32_t i, x = 0;
-//    uint8_t buf[BUF_LEN];
-//
-//    // Note: we're assuming the ARM is BE
-//    memcpy(buf, &length, sizeof(length));
-//    HAL_UART_Transmit(&huart1, (uint8_t *) buf, sizeof(length), 100);
-//
-//    for (i=0; i<length; i++) {
-//        prev = curr;
-//        curr = read_fifo(sensor);
-//        if ((curr == 0xd9) && (prev == 0xff)) {
-//            // found the footer - break
-//            buf[x++] = curr;
-//            HAL_UART_Transmit(&huart1, buf, x, 100);
-//            x = 0;
-//            i++;
-//            found_header = false;
-//            break;
-//        }
-//
-//        if (found_header) {
-//            buf[x] = curr;
-//            x++;
-//            if (x >= BUF_LEN) {
-//                HAL_UART_Transmit(&huart1, buf, BUF_LEN, 100);
-//                x = 0;
-//            }
-//        }
-//        else if ((curr == 0xd8) && (prev = 0xff)) {
-//            found_header = true;
-//            buf[0] = prev;
-//            buf[1] = curr;
-//            HAL_UART_Transmit(&huart1, (uint8_t *) buf, 2, 100);
-//            x = 0;
-//        }
-//    }
-//
-//    if (x) {
-//        HAL_UART_Transmit(&huart1, buf, x, 100);
-//    }
-//
-//    if (found_header) {
-//        // We found the header but not the footer :-(
-//        buf[0] = 0xff;
-//        buf[1] = 0xd9;
-//        HAL_UART_Transmit(&huart1, (uint8_t *) buf, 2, 100);
-//    }
-//    else {
-//        memset(buf, 0, BUF_LEN);
-//        while (i < length) {
-//            int cnt = min(length - i, BUF_LEN);
-//            HAL_UART_Transmit(&huart1, (uint8_t *) buf, cnt, 100);
-//            i += cnt;
-//        }
-//    }
-//}
+static void dump_uart_jpg_burst(uint32_t length, uint8_t sensor) {
+
+	uint8_t BUF_LEN = 64;
+    uint8_t prev = 0, curr = 0;
+    bool found_header = false;
+    uint32_t i, x = 0;
+    uint8_t buf[BUF_LEN];
+
+    // Note: we're assuming the ARM is BE
+    memcpy(buf, &length, sizeof(length));
+    HAL_UART_Transmit(&huart1, (uint8_t *) buf, sizeof(length), 100);
+
+    spi_init_burst(sensor);
+    for (i=0; i<length; i++) {
+        prev = curr;
+        curr = spi_read_burst(sensor);
+        if ((curr == 0xd9) && (prev == 0xff)) {
+            // found the footer - break
+            buf[x++] = curr;
+            HAL_UART_Transmit(&huart1, buf, x, 100);
+            x = 0;
+            i++;
+            found_header = false;
+            break;
+        }
+
+        if (found_header) {
+            buf[x] = curr;
+            x++;
+            if (x >= BUF_LEN) {
+                HAL_UART_Transmit(&huart1, buf, BUF_LEN, 100);
+                x = 0;
+            }
+        }
+        else if ((curr == 0xd8) && (prev = 0xff)) {
+            found_header = true;
+            buf[0] = prev;
+            buf[1] = curr;
+            HAL_UART_Transmit(&huart1, (uint8_t *) buf, 2, 100);
+            x = 0;
+
+        }
+    }
+    spi_deinit_burst(sensor);
+
+    if (x) {
+        HAL_UART_Transmit(&huart1, buf, x, 100);
+    }
+
+    if (found_header) {
+        // We found the header but not the footer :-(
+        buf[0] = 0xff;
+        buf[1] = 0xd9;
+        HAL_UART_Transmit(&huart1, (uint8_t *) buf, 2, 100);
+    }
+    else {
+        memset(buf, 0, BUF_LEN);
+        while (i < length) {
+            int cnt = min(length - i, BUF_LEN);
+            HAL_UART_Transmit(&huart1, (uint8_t *) buf, cnt, 100);
+            i += cnt;
+        }
+    }
+}
 //
 //static void uart_dump_buf(uint8_t *data, uint16_t len) {
 //    char digit[4];
@@ -613,42 +620,31 @@ static inline uint32_t min(uint32_t a, uint32_t b) { return (a <= b) ? a : b; }
 
 //
 //
-//void SingleCapTransfer(int format, uint8_t sensor) {
-//    char buf[64];
-//    uint32_t length;
-//
-//    sprintf(buf, "Single Capture Transfer type %x\r\n", format);
-//    DBG_PUT(buf);
-//    write_reg(ARDUCHIP_TIM, VSYNC_LEVEL_MASK, sensor); // VSYNC is active HIGH
-//    uint8_t val;
-//    rdSensorReg16_8(REG_FORMAT_CTL, &val, sensor);
-//    sprintf(buf, "format reg: 0x%02x\r\n", val);
-//    DBG_PUT(buf);
-//
-//    flush_fifo(sensor);
-//    clear_fifo_flag(sensor);
-//    start_capture(sensor);
-//
-//    while (!get_bit(ARDUCHIP_TRIG, CAP_DONE_MASK, sensor)) {
-//    }
-//
-//    length = read_fifo_length(sensor);
-//    sprintf(buf, "Capture complete! FIFO len 0x%lx\r\n", length);
-//    DBG_PUT(buf);
-//    DBG_PUT("JPG");
-//
-//    switch (format) {
-//    case BMP:
-//        dump_uart_bmp(sensor);
-//        break;
-//    case RAW:
-//        dump_uart_raw(length * 2, sensor);
-//        break;
-//    default:
-//        break;
-//    }
-//
-//    DBG_PUT("\04");
-//}
+void SingleCapTransfer(int format, uint8_t sensor) {
+    char buf[64];
+    uint32_t length;
+
+    sprintf(buf, "Single Capture Transfer type %x\r\n", format);
+    DBG_PUT(buf);
+    write_reg(ARDUCHIP_TIM, VSYNC_LEVEL_MASK, sensor); // VSYNC is active HIGH
+    uint8_t val;
+    rdSensorReg16_8(REG_FORMAT_CTL, &val, sensor);
+    sprintf(buf, "format reg: 0x%02x\r\n", val);
+    DBG_PUT(buf);
+
+    flush_fifo(sensor);
+    clear_fifo_flag(sensor);
+    start_capture(sensor);
+
+    while (!get_bit(ARDUCHIP_TRIG, CAP_DONE_MASK, sensor)) {
+    }
+
+    length = read_fifo_length(sensor);
+    sprintf(buf, "Capture complete! FIFO len 0x%lx\r\n", length);
+    DBG_PUT(buf);
+    DBG_PUT("JPG");
+    dump_uart_jpg_burst(length, sensor);
+    DBG_PUT("\04");
+}
 
 void set_image_num(uint8_t num) { image_number = num; }

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -550,11 +550,12 @@ static void onboot_commands(void) {
 #endif //CURRENTSENSE_5V
     flood_cam_spi();
     init_temp_sensors();
+
 #ifdef IRIS_PROTO
 	sensor_togglepower(1);
 	initalize_sensors();
 #endif //IRIS_PROTO
-	// end move
+
 #ifdef UART_DEBUG
     DBG_PUT("-----------------------------------\r\n");
     DBG_PUT("Iris Electronics Test Software\r\n"

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -46,7 +46,7 @@
 /* USER CODE BEGIN PD */
 
 int format = JPEG;
-int width = 1280;
+int width = 2592;
 
 /* USER CODE END PD */
 
@@ -548,11 +548,11 @@ static void onboot_commands(void) {
 #ifdef CURRENTSENSE_5V
     init_ina209(CURRENTSENSE_5V);
 #endif //CURRENTSENSE_5V
-    flood_cam_spi();
     init_temp_sensors();
 
 #ifdef IRIS_PROTO
 	sensor_togglepower(1);
+    flood_cam_spi();
 	initalize_sensors();
 #endif //IRIS_PROTO
 

--- a/Core/Src/sys_cmds.c
+++ b/Core/Src/sys_cmds.c
@@ -3,64 +3,10 @@
 #include "command_handler.h"
 #include "debug.h"
 
-uint8_t VIS_DETECTED = 0;
-uint8_t NIR_DETECTED = 0;
+
 
 extern I2C_HandleTypeDef hi2c2;
 
-
-/**
- * @brief Resets target sensor to default parameters
- *
- * @param sensor
- */
-void sensor_reset(uint8_t sensor) {
-    char buf[64];
-
-    arducam_wait_for_ready(sensor);
-
-    // Reset the CPLD
-    write_reg(AC_REG_RESET, 1, sensor);
-    HAL_Delay(100);
-    write_reg(AC_REG_RESET, 0, sensor);
-    HAL_Delay(100);
-
-    if (!arducam_wait_for_ready(sensor)) {
-        DBG_PUT("VIS Camera: SPI Unavailable\r\n");
-    } else {
-        DBG_PUT("VIS Camera: SPI Initialized\r\n");
-    }
-
-    // Change MCU mode
-    write_reg(ARDUCHIP_MODE, 0x0, sensor);
-    wrSensorReg16_8(0xff, 0x01, sensor);
-
-    uint8_t vid = 0, pid = 0;
-    rdSensorReg16_8(OV5642_CHIPID_HIGH, &vid, sensor);
-    rdSensorReg16_8(OV5642_CHIPID_LOW, &pid, sensor);
-
-    int detected = VIS_DETECTED;
-    if (sensor == NIR_SENSOR) {
-        detected = NIR_DETECTED;
-    } else if (sensor != VIS_SENSOR) {
-        sprintf(buf, "illegal sensor %d\r\n", sensor);
-        DBG_PUT(buf);
-    }
-
-    if (vid != 0x56 || pid != 0x42) {
-        sprintf(buf, "Camera I2C Address: Unknown\r\nVIS not available\r\n\n");
-        DBG_PUT(buf);
-        detected = 0;
-    } else {
-        detected = 1;
-        format = JPEG;
-        program_sensor(format, sensor);
-        sprintf(buf, "Camera Mode: JPEG\r\n");
-        DBG_PUT(buf);
-    }
-
-    HAL_Delay(1000);
-}
 
 /**
  * @brief Scans I2C2 (internal) bus for devices. Debug purpose only

--- a/Core/Src/uart_command_handler.c
+++ b/Core/Src/uart_command_handler.c
@@ -10,6 +10,7 @@
 #include "housekeeping.h"
 extern int format;
 extern I2C_HandleTypeDef hi2c2;
+extern UART_HandleTypeDef huart1;
 
 
 static inline const char *next_token(const char *ptr) {
@@ -260,12 +261,10 @@ void uart_handle_capture_cmd(const char *cmd) {
     int target_sensor;
     switch (*wptr) {
     case 'v':
-#ifndef FAKE_CAM
         if (VIS_DETECTED == 0) {
             DBG_PUT("VIS Unavailable.\r\n");
             return;
         }
-#endif
         target_sensor = VIS_SENSOR; // vis = 0
         break;
 
@@ -281,7 +280,8 @@ void uart_handle_capture_cmd(const char *cmd) {
         return;
     }
 
-    arducam_capture_image(target_sensor);
+//    arducam_capture_image(target_sensor);
+    SingleCapTransfer(format, target_sensor);
 }
 
 void uart_handle_xfer_cmd(const char *cmd) {
@@ -495,3 +495,5 @@ void print_progress(uint8_t count, uint8_t max) {
         DBG_PUT("\r\n");
     }
 }
+
+


### PR DESCRIPTION
Enables burst readout from the arducam modules, significantly speeding up image transfer time. Arducam refactor PR should be merged ahead of this, as it builds on the refactor.

Notable changes:
- burst mode!
- enabled full resolution for jpegs
- moves refactored functions into command_handler.c