### PR TITLE
jenish/hotfix/fix-spi-receive-from-obc

### DIFF
--- a/Core/Src/spi_command_handler.c
+++ b/Core/Src/spi_command_handler.c
@@ -45,7 +45,8 @@ void spi_receive(uint8_t *rx_data, uint16_t data_length) { HAL_SPI_Receive_IT(&h
  * 		data_length: numbers of bytes to be receive
  */
 void spi_receive_blocking(uint8_t *rx_data, uint16_t data_length) {
-    HAL_SPI_Receive(&hspi1, rx_data, data_length, HAL_MAX_DELAY);
+    uint8_t tx_dummy = 0xFF;
+    HAL_SPI_TransmitReceive(&hspi1, &tx_dummy, rx_data, data_length, HAL_MAX_DELAY);
 }
 
 /**


### PR DESCRIPTION
For some unknown reason when using `HAL_SPI_Receive()` for getting data FROM the obc it causes following commands to be incorrectly acknowledge (it is hard to explain in sentence). Although when trying with `HAL_SPI_TransmitReceive` everything works!